### PR TITLE
Add madrasa banner to word.asp

### DIFF
--- a/word.asp
+++ b/word.asp
@@ -136,7 +136,7 @@ closeDbLogger "arabicWords","C","word.asp","Words Main",durationMs,wordId+" "+he
             font-size: 1em;
         }
 
-        h2 {
+        main h2 {
             background-color: #8cc3fd;
             font-weight: 100;
             padding: 4px;
@@ -262,7 +262,7 @@ closeDbLogger "arabicWords","C","word.asp","Words Main",durationMs,wordId+" "+he
 </head>
 <body>
 <!--#include file="inc/top.asp"-->
-
+<!--#include file="inc/banner.asp"-->
 
 <main class="flex-container">
     <section class="sctRight">


### PR DESCRIPTION
## Summary
- Add `inc/banner.asp` include to `word.asp` (after `inc/top.asp`)
- Fix unscoped `h2` CSS rule — changed `h2` to `main h2` so it no longer overrides banner styles (was causing letter-spacing, padding, and max-width to bleed into the banner heading)

## Test plan
- [x] Visit `/word.asp?id=592` and confirm the banner looks identical to the homepage banner
- [x] Confirm section headings inside the word page still have their blue background styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)